### PR TITLE
feat. 게시글 페이지네이션 추가 및 UX 관련 대응

### DIFF
--- a/src/components/board/BoardItem.jsx
+++ b/src/components/board/BoardItem.jsx
@@ -21,11 +21,11 @@ const BoardItem = ({ item }) => {
           <Title>{item.title}</Title>
           <TextBody>{item.body}</TextBody>
           <InfoTextWrap>
-            <Typography variant="body2" sx={{ mr: 4, color: "#999" }}>
+            <Typography variant="body2" sx={{ mr: 6, color: "#999" }}>
               댓글 {item.comments}개
             </Typography>
-            <Typography variant="body2" sx={{ mr: 4, color: "#999" }}>
-              by {item.username}
+            <Typography variant="body2" sx={{ mr: 2, color: "#999" }}>
+              <Nickname>by {item.username}</Nickname>
             </Typography>
             <Typography variant="body2" sx={{ color: "#999" }}>
               {new Date(item.createdDate).toLocaleString().slice(0, 12)}
@@ -100,4 +100,12 @@ const TextBody = styled.p`
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+`;
+
+const Nickname = styled.span`
+  display: inline-block;
+  width: 100px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;

--- a/src/components/board/BoardList.jsx
+++ b/src/components/board/BoardList.jsx
@@ -5,16 +5,17 @@ import BoardItem from "./BoardItem";
 import Button from "../button/Button";
 import { Typography } from "@mui/material";
 import styled from "styled-components";
-import { getBoard } from "../../store/modules/boardSlice";
+import { getBoard, getAllBoard } from "../../store/modules/boardSlice";
 
 const BoardList = () => {
   const board = useSelector((state) => state.boardSlice.list);
   const dispatch = useDispatch();
   const location = useLocation();
+
   const currentLocation = location.pathname.slice(1);
 
   useEffect(() => {
-    dispatch(getBoard());
+    !currentLocation ? dispatch(getBoard()) : dispatch(getAllBoard());
   }, [dispatch]);
 
   return (
@@ -30,11 +31,11 @@ const BoardList = () => {
           <BoardItem key={item.id} item={item} />
         ))}
       </div>
-      <ButtonWrap page={currentLocation === "" ? "main" : "board"}>
+      <ButtonWrap page={!currentLocation ? "main" : "board"}>
         <Button
-          size={currentLocation === "" ? "primary" : "secondary"}
-          type={currentLocation === "" ? "more" : "editor"}
-          text={currentLocation === "" ? "더보기" : "글쓰기"}
+          size={!currentLocation ? "primary" : "secondary"}
+          type={!currentLocation ? "more" : "editor"}
+          text={!currentLocation ? "더보기" : "글쓰기"}
         />
       </ButtonWrap>
     </Section>

--- a/src/components/board/BoardList.jsx
+++ b/src/components/board/BoardList.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react";
 import { useLocation, Link } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
-import BoardItem from "./BoardItem";
-import Button from "../button/Button";
-import { Typography, Pagination } from "@mui/material";
 import styled from "styled-components";
+import { Typography, Pagination } from "@mui/material";
+import Button from "../button/Button";
+import BoardItem from "./BoardItem";
+import NoContent from "../error/NoContent";
 import { getBoard, getAllBoard } from "../../store/modules/boardSlice";
 
 const BoardList = () => {
@@ -23,12 +24,27 @@ const BoardList = () => {
   useEffect(() => {
     // currentLocation === "" 인 경우 (falsy한 값) getAllBoard() 실행
     !currentLocation ? dispatch(getBoard()) : dispatch(getAllBoard());
-  }, [dispatch]);
+  }, [currentLocation, dispatch]);
 
   // 페이지 이동 핸들러
   const handlePageChange = (event) => {
     const currentPageIndex = Number(event.target.outerText);
     setCurrentPage(currentPageIndex);
+  };
+
+  // 게시글 리스트 렌더링 핸들러
+  const handleBoardList = () => {
+    if (board.length === 0) {
+      return <NoContent />;
+    }
+    // currentLocation === "" 인 경우 최신순 5개 일괄 출력 / 아닐 경우 페이지네이션 적용
+    if (!currentLocation) {
+      return board.map((item) => <BoardItem key={item.id} item={item} />);
+    } else {
+      return board
+        .slice(5 * (currentPage - 1), 5 * (currentPage - 1) + 5)
+        .map((item) => <BoardItem key={item.id} item={item} />);
+    }
   };
 
   return (
@@ -39,31 +55,28 @@ const BoardList = () => {
       >
         <Link to={"/board"}>Board</Link>
       </Typography>
-      <div>
-        {!currentLocation &&
-          board.map((item) => <BoardItem key={item.id} item={item} />)}
-        {currentLocation &&
-          board
-            .slice(5 * (currentPage - 1), 5 * (currentPage - 1) + 5)
-            .map((item) => <BoardItem key={item.id} item={item} />)}
-      </div>
-      <ButtonWrap page={!currentLocation ? "main" : "board"}>
-        <Button
-          size={!currentLocation ? "primary" : "secondary"}
-          type={!currentLocation ? "more" : "editor"}
-          text={!currentLocation ? "더보기" : "글쓰기"}
-        />
-      </ButtonWrap>
-      <PaginationWrap>
-        {currentLocation && (
-          <Pagination
-            page={currentPage}
-            count={LAST_PAGE}
-            defaultPage={1}
-            onChange={handlePageChange}
+      <div>{handleBoardList()}</div>
+      {board.length !== 0 && (
+        <ButtonWrap page={!currentLocation ? "main" : "board"}>
+          <Button
+            size={!currentLocation ? "primary" : "secondary"}
+            type={!currentLocation ? "more" : "editor"}
+            text={!currentLocation ? "더보기" : "글쓰기"}
           />
-        )}
-      </PaginationWrap>
+        </ButtonWrap>
+      )}
+      {board.length !== 0 && (
+        <PaginationWrap>
+          {currentLocation && (
+            <Pagination
+              page={currentPage}
+              count={LAST_PAGE}
+              defaultPage={1}
+              onChange={handlePageChange}
+            />
+          )}
+        </PaginationWrap>
+      )}
     </Section>
   );
 };

--- a/src/components/board/BoardList.jsx
+++ b/src/components/board/BoardList.jsx
@@ -1,9 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, Link } from "react-router-dom";
 import { useSelector, useDispatch } from "react-redux";
 import BoardItem from "./BoardItem";
 import Button from "../button/Button";
-import { Typography } from "@mui/material";
+import { Typography, Pagination } from "@mui/material";
 import styled from "styled-components";
 import { getBoard, getAllBoard } from "../../store/modules/boardSlice";
 
@@ -11,12 +11,25 @@ const BoardList = () => {
   const board = useSelector((state) => state.boardSlice.list);
   const dispatch = useDispatch();
   const location = useLocation();
+  const [currentPage, setCurrentPage] = useState(1);
 
+  // 마지막 페이지 계산
+  const LAST_PAGE =
+    board.length % 5 === 0
+      ? parseInt(board.length / 5)
+      : parseInt(board.length / 5) + 1;
   const currentLocation = location.pathname.slice(1);
 
   useEffect(() => {
+    // currentLocation === "" 인 경우 (falsy한 값) getAllBoard() 실행
     !currentLocation ? dispatch(getBoard()) : dispatch(getAllBoard());
   }, [dispatch]);
+
+  // 페이지 이동 핸들러
+  const handlePageChange = (event) => {
+    const currentPageIndex = Number(event.target.outerText);
+    setCurrentPage(currentPageIndex);
+  };
 
   return (
     <Section>
@@ -27,9 +40,12 @@ const BoardList = () => {
         <Link to={"/board"}>Board</Link>
       </Typography>
       <div>
-        {board.map((item) => (
-          <BoardItem key={item.id} item={item} />
-        ))}
+        {!currentLocation &&
+          board.map((item) => <BoardItem key={item.id} item={item} />)}
+        {currentLocation &&
+          board
+            .slice(5 * (currentPage - 1), 5 * (currentPage - 1) + 5)
+            .map((item) => <BoardItem key={item.id} item={item} />)}
       </div>
       <ButtonWrap page={!currentLocation ? "main" : "board"}>
         <Button
@@ -38,6 +54,16 @@ const BoardList = () => {
           text={!currentLocation ? "더보기" : "글쓰기"}
         />
       </ButtonWrap>
+      <PaginationWrap>
+        {currentLocation && (
+          <Pagination
+            page={currentPage}
+            count={LAST_PAGE}
+            defaultPage={1}
+            onChange={handlePageChange}
+          />
+        )}
+      </PaginationWrap>
     </Section>
   );
 };
@@ -49,10 +75,16 @@ const ButtonWrap = styled.div`
   justify-content: ${(props) =>
     props.page === "main" ? "center" : "flex-end"};
   align-items: center;
-  margin: 2rem 0 7rem;
+  margin: 1rem 0;
   padding-right: ${(props) => (props.page === "board" ? "3rem" : "")};
 `;
 
 const Section = styled.section`
   margin: 3rem 0 4rem;
+`;
+
+const PaginationWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  margin: 0.6rem 0 5rem;
 `;

--- a/src/components/error/NoContent.jsx
+++ b/src/components/error/NoContent.jsx
@@ -1,0 +1,32 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faFaceDizzy } from "@fortawesome/free-regular-svg-icons";
+import { Box, Typography } from "@mui/material";
+import styled from "styled-components";
+
+const NoContent = () => {
+  return (
+    <Box
+      sx={{
+        my: 10,
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        flexDirection: "column",
+      }}
+    >
+      <EmojiWrap>
+        <FontAwesomeIcon icon={faFaceDizzy} />
+      </EmojiWrap>
+      <Typography variant="body1" sx={{ color: "#999" }}>
+        등록된 콘텐츠가 없어요!
+      </Typography>
+    </Box>
+  );
+};
+
+export default NoContent;
+
+const EmojiWrap = styled.div`
+  font-size: 7rem;
+  color: #ccc;
+`;

--- a/src/pages/Footer.jsx
+++ b/src/pages/Footer.jsx
@@ -33,6 +33,7 @@ export default Footer;
 const FooterWrap = styled.footer`
   width: 100%;
   background-color: #f2f2f2;
+  margin-top: 3rem;
 `;
 
 const CopyRight = styled.p`

--- a/src/store/modules/boardSlice.js
+++ b/src/store/modules/boardSlice.js
@@ -12,8 +12,23 @@ export const getBoard = createAsyncThunk(
   "getBoard",
   async (payload, thunkAPI) => {
     try {
-      const response = await axios.get("http://localhost:8080/board");
+      const response = await axios.get(
+        `http://localhost:8080/board?_sort=createdDate&_order=DESC&_limit=5`
+      );
+      return thunkAPI.fulfillWithValue(response.data);
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error);
+    }
+  }
+);
 
+export const getAllBoard = createAsyncThunk(
+  "getAllBoard",
+  async (payload, thunkAPI) => {
+    try {
+      const response = await axios.get(
+        `http://localhost:8080/board?_sort=createdDate&_order=DESC`
+      );
       return thunkAPI.fulfillWithValue(response.data);
     } catch (error) {
       return thunkAPI.rejectWithValue(error);
@@ -30,6 +45,12 @@ const boardSlice = createSlice({
       state.list = action.payload;
     },
     [getBoard.rejected]: (state, action) => {
+      state.error = action.payload;
+    },
+    [getAllBoard.fulfilled]: (state, action) => {
+      state.list = action.payload;
+    },
+    [getAllBoard.rejected]: (state, action) => {
       state.error = action.payload;
     },
   },


### PR DESCRIPTION
* 페이지에 따라 게시글 개수를 다르게 불러오도록 수정 (메인: 최신순 5개, 보드: 전체)
* footer 상단 여백 추가
* 페이지네이션 추가
* 게시글 목록 닉네임 말줄임표 처리
* 게시글 개수가 0개일 경우에 대한 대응 